### PR TITLE
Add mode parameter to plaits

### DIFF
--- a/files/mutable-instruments-synthdefs.scd
+++ b/files/mutable-instruments-synthdefs.scd
@@ -32,7 +32,7 @@
 
 (
   SynthDef(\plaits, {|out=0,freq=440,sustain=1,pan=0,begin=0,end=1,speed=1,accelerate=0,
-      timbre=0.5,engine=0,harm=0.5,morph=0.5,level=1,lpgdecay=0,lpgcolour=0|
+      timbre=0.5,engine=0,harm=0.5,morph=0.5,level=1,lpgdecay=0,lpgcolour=0,mode=0|
     var envLength = sustain*(end-begin)/speed;
     var line = Line.ar(begin, end, envLength, doneAction: Done.freeSelf);
     var env = Env.asr;
@@ -50,8 +50,7 @@
       decay: lpgdecay,
       lpg_colour: lpgcolour,
     );
-    sig = SplayAz.ar(~dirt.numChannels, sig, center:pan);
-
+    sig = Select.ar(mode, sig);
     Out.ar(out, DirtPan.ar(sig * volume, ~dirt.numChannels, pan));
   }).add;
 );


### PR DESCRIPTION
The return value of MiPlaits is an array of two signals. Unlike most multiple-output UGens, these don't represent stereo signals; instead, the first signal is designated the primary output and the second, the auxiliary output (or AUX in the docs) represents a skewed/altered/lofi version of the primary output. Before this patch, these signals were getting mixed together, which is why some of these drums sounded so weird. Introducing the `mode` parameter allows us to toggle between the primary and auxiliary channels.

This is a backwards-incompatible change to the synth, but you can recover the original behavior by passing `[0|1]` as the `mode` parameter.

Additionally, we can remove the `SplayAz` trick, as the presence of the `Select` UGen cuts `sig` down to one signal, and `DirtPan` takes care of splaying a single channel across the available channels.